### PR TITLE
Add array? / array-type?

### DIFF
--- a/test/sweet_array/core_test.clj
+++ b/test/sweet_array/core_test.clj
@@ -56,6 +56,16 @@
   (is (not (sa/instance? [[long]] (long-array [1 2 3]))))
   (is (not (sa/instance? [double] (make-array Double/TYPE 0 0)))))
 
+(deftest array-type?-test
+  (is (sa/array-type? (sa/type [String])))
+  (is (not (sa/array-type? String)))
+  (is (not (sa/array-type? nil))))
+
+(deftest array?-test
+  (is (sa/array? (sa/new [int] [1 2 3])))
+  (is (not (sa/array? 42)))
+  (is (not (sa/array? nil))))
+
 (deftest cast-test
   (let [arr (make-array Integer/TYPE 0)
         arr' (sa/cast [int] arr)]


### PR DESCRIPTION
Adds these predicates:

- `array?`: Returns true if and only if the given object is an array
- `array-type?`: Returns true if and only if the given type is an array type